### PR TITLE
Modification of some functions of the epipe pipeline

### DIFF
--- a/R/DMPextr.R
+++ b/R/DMPextr.R
@@ -44,7 +44,8 @@
 #                   writeOut = FALSE)                    # write output to file
 DMPextr <- function(
     fit, ContrastsDM = colnames(fit$contrasts), p.value, beta_normalized, betas_idx = NULL,
-    mDiff, ann = NULL, writedir = "analysis/DMP_", writeOut = TRUE, ncores = NULL, columns = TRUE
+    mDiff, ann = NULL, writedir = "analysis/DMP_", writeOut = TRUE, ncores = NULL, columns = TRUE,
+    OS = "Linux"
 ) {
 
   # Check if annotation is provided, if not, use Illumina annotation
@@ -73,7 +74,14 @@ DMPextr <- function(
   if (is.null(ncores)) ncores <- length(ContrastsDM)
 
   # Initialize parallel cluster
-  cl <- parallel::makeCluster(ncores, outfile = "", useXDR = FALSE, type = "FORK")
+  if(OS == "Linux"){
+    OS_type <- "FORK"
+  }else if (OS == "Windows"){
+    OS_type <- "PSOCK"
+  }
+  
+  cl <- parallel::makeCluster(ncores, outfile = "", useXDR = FALSE, type = OS_type)
+  
   parallel::clusterEvalQ(
     cl, {
       requireNamespace(c("limma", "data.table"))

--- a/R/find_dmrs2.R
+++ b/R/find_dmrs2.R
@@ -31,8 +31,13 @@
 
 
 find_dmrs<-function(beta_values,model,fdr = 0.01, p.value = "fdr", bcutoff = 0.05, min.cpg = 5,pal,output_dir='./',arraytype){
-
-  m_values <- minfi::logit2(beta_values)
+  
+  # CpGs names must be in rownames and not be a column of the beta values matrix
+  beta_values_dmrs <- beta_values[, !(names(beta_values) %in% "X")]
+  rownames(beta_values_dmrs) <- beta_values$X
+  beta_values_dmrs <- as.matrix(beta_values_dmrs)
+  
+  m_values <- minfi::logit2(beta_values_dmrs)
 
   # Contrast matrix
   contrast_matrix <- model$contrasts

--- a/R/mod.R
+++ b/R/mod.R
@@ -9,7 +9,7 @@
 #' @param betas_idx A matrix or data frame providing the indices for the beta values if object class is FBM.
 #' @param group_var  A string specifying the column name for the grouping variable.
 #' @param covs.formula Formula for specifying covariates in the model.
-#' @param contrasts Optional string of semicolon-separated contrasts. If not provided, automatic contrasts are generated.
+#' @param contrasts Optional string of semicolon-separated contrasts. If not provided, automatic contrasts are generated. A contrast must have the format "Category1-Category2" because the design variable transforms the category values into column names. Then, limma::makeContrasts function interprets the "contrasts" variable and uses it in the model created by the design matrix. 
 #' @param covs A character vector specifying additional covariates.
 #' @param metadata The metadata or sample sheet.
 #' @param set A boolean vector to subset the observations.

--- a/R/prep.R
+++ b/R/prep.R
@@ -95,7 +95,7 @@ remove_cross_reactive_probes <- function(mSetSqn, sexchr) {
     # For other arrays, use maxprobes::dropXreactiveLoci
     mSetSqn <- maxprobes::dropXreactiveLoci(mSetSqn)
   }
-  metadata(mSetSqn)$removed_sex <- setdiff(probeID_start,rownames(mSetSqn))
+  metadata(mSetSqn)$removed_cross_reactive <- setdiff(probeID_start,rownames(mSetSqn))
   return(mSetSqn)
 }
 


### PR DESCRIPTION
I have slightly modified 4 functions from the epipe pipeline to correct some little errors and add more options (they are described in each commit):

1- Add OS option to the cl variable creation in DMPextr function. If the OS is Linux, type is FORK. If the OS is Windows, type is PSOCK.

2- Cross-reactive probes are added to metadata in the variable removed_cross_reactive (line 98). Before, it was added to removed_sex, so they are overwritten when removed sex probes are stored.

3- To create m_values, the first column of beta values matrix called X is the name of CpGs. Store this column values in the rownames and remove the column.

4- Add more description to atribute contrasts. This variable must have the format Category1-Category2.

